### PR TITLE
chore: target Android 16 (API 36) for Google Play compliance

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,9 +46,9 @@ android {
     defaultConfig {
         applicationId = "com.rwothoromo.devfinder"
         minSdk = 23
-        targetSdk = 35
-        versionCode = 3
-        versionName = "1.0.3"
+        targetSdk = 36
+        versionCode = 4
+        versionName = "1.0.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         // The app's state will be completely cleared between tests.
         testInstrumentationRunnerArguments clearPackageData: 'true'


### PR DESCRIPTION
## Why
Google Play flagged the app: from **Aug 31, 2026** an app must target within one year of the latest Android release. The app's target was Android 15 (API 35); Play requires **Android 16 (API 36)** or higher.

## What changed
`app/build.gradle`:
- `targetSdk` 35 → **36** (`compileSdk` was already 36)
- `versionCode` 3 → **4** and `versionName` 1.0.3 → **1.0.4** so a new production version can be published

## Deploy
Merging to `develop` triggers the CI pipeline which builds and deploys the AAB to Google Play. After the update publishes to production, Google Play will confirm the app is no longer affected.

## Notes
- The CircleCI instrumentation-test emulator image is left at `android-35`. An app with `targetSdk = 36` runs correctly on an API 35 device — `targetSdk` is a compatibility declaration, not a minimum — so tests are unaffected.
- Recommend a quick pass on Android 16 behavior changes (edge-to-edge enforcement, etc.) via an internal/closed testing track before promoting to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)